### PR TITLE
[BUG]: Move Overwritten

### DIFF
--- a/TicTacToe/Views/GameBoard.cs
+++ b/TicTacToe/Views/GameBoard.cs
@@ -135,8 +135,13 @@ public class GameBoard(BaseGame game) : BaseScreen
                 break;
             case ConsoleKey.X:
             case ConsoleKey.O:
-                if (_game.CurrentHand?.ToString() != consoleKey.ToString() || _game.Winner != null)
+                var isWinnerExists = _game.Winner != null;
+                var isCellOccupied = _game.Board[SelectedRow, SelectedCol] != null;
+                var isDifferentHand = _game.CurrentHand?.ToString() != consoleKey.ToString();
+
+                if (isWinnerExists || isCellOccupied || isDifferentHand)
                     break;
+
                 _game.Board[SelectedRow, SelectedCol] = _game.CurrentHand;
                 _game.UpdateWinner();
                 _game.NextTurn();


### PR DESCRIPTION
This PR addresses a critical bug in the Tic Tac Toe game where Player 2 can overwrite Player 1's move by placing their marker in an already occupied square. This unintended behavior disrupts the turn-based nature of the game and can lead to confusion during gameplay.

### Changes Introduced
- Fix `GameBoard` `Input()`

Closes #8 